### PR TITLE
Streamline dist client state management and prune remaining `reqwest::blocking` client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ native-zlib = []
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the cachepot client
-dist-client = ["ar", "flate2", "hyper", "hyperx", "reqwest", "url", "sha2"]
+dist-client = ["ar", "flate2", "hyper", "hyperx", "reqwest/stream", "url", "sha2", "tokio/fs"]
 # Enables the cachepot-dist binary
 dist-server = ["chrono", "crossbeam-utils", "jsonwebtoken", "flate2", "hyperx", "libmount", "nix", "reqwest", "rouille", "sha2", "syslog", "void", "version-compare"]
 # Enables dist tests with external requirements

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1182,26 +1182,13 @@ mod client {
                         .await
                         .context("GET to scheduler server_certificate failed")?;
 
-                    // TODO: Move to asynchronous reqwest client only.
-                    // This function internally builds a blocking reqwest client;
-                    // However, it does so by utilizing a runtime which it drops,
-                    // triggering (rightfully) a sanity check that prevents from
-                    // dropping a runtime in asynchronous context.
-                    // For the time being, we work around this by off-loading it
-                    // to a dedicated blocking-friendly thread pool.
-                    let _ = self
-                        .pool
-                        .spawn_blocking(move || {
-                            Self::update_certs(
-                                &mut client_async.lock().unwrap(),
-                                &mut server_certs.lock().unwrap(),
-                                res.cert_digest,
-                                res.cert_pem,
-                            )
-                            .context("Failed to update certificate")
-                            .unwrap_or_else(|e| warn!("Failed to update certificate: {:?}", e));
-                        })
-                        .await;
+                    Self::update_certs(
+                        &mut client_async.lock().unwrap(),
+                        &mut server_certs.lock().unwrap(),
+                        res.cert_digest,
+                        res.cert_pem,
+                    )
+                    .unwrap_or_else(|e| warn!("Failed to update certificate: {:?}", e));
 
                     alloc_job_res
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -276,7 +276,7 @@ impl DistClientContainer {
                 // Move out the boxed config to re-use it when re-creating state
                 let config = match mem::replace(state, DistClientState::Disabled) {
                     DistClientState::RetryCreateAt(config, _) => config,
-                    _ => unreachable!(),
+                    _ => unreachable!("just checked above"),
                 };
                 info!("Attempting to recreate the dist client");
                 *state = Self::create_state(config)
@@ -289,7 +289,7 @@ impl DistClientContainer {
                 // Move out the boxed config to re-use it when re-creating state
                 let (config, msg) = match mem::replace(state, DistClientState::Disabled) {
                     DistClientState::FailWithMessage(config, msg) => (config, msg),
-                    _ => unreachable!(),
+                    _ => unreachable!("just checked above"),
                 };
                 // The client is most likely mis-configured, make sure we
                 // re-create on our next attempt.

--- a/src/server.rs
+++ b/src/server.rs
@@ -295,7 +295,7 @@ impl DistClientContainer {
                 // re-create on our next attempt.
                 *state = DistClientState::RetryCreateAt(config, Instant::now());
 
-                Err(anyhow!(msg.clone()))
+                Err(anyhow!(msg))
             }
             DistClientState::Some(_, ref dc) => Ok(Some(Arc::clone(dc))),
             DistClientState::Disabled | DistClientState::RetryCreateAt(_, _) => Ok(None),

--- a/src/server.rs
+++ b/src/server.rs
@@ -225,8 +225,7 @@ impl DistClientContainer {
             | DistClientState::FailWithMessage(cfg, _)
             | DistClientState::RetryCreateAt(cfg, _) => {
                 warn!("State reset. Will recreate");
-                *state =
-                    DistClientState::RetryCreateAt(cfg, Instant::now() - Duration::from_secs(1));
+                *state = DistClientState::RetryCreateAt(cfg, Instant::now());
             }
             DistClientState::Disabled => (),
         }
@@ -294,8 +293,7 @@ impl DistClientContainer {
                 };
                 // The client is most likely mis-configured, make sure we
                 // re-create on our next attempt.
-                *state =
-                    DistClientState::RetryCreateAt(config, Instant::now() - Duration::from_secs(1));
+                *state = DistClientState::RetryCreateAt(config, Instant::now());
 
                 Err(anyhow!(msg.clone()))
             }


### PR DESCRIPTION
This is an attempt to fix #85 (and is an overdue cleanup).

First 3 commits do the aforementioned streamlining, while the remaining commits prune the remaining blocking `reqwest` client. Since we can now leverage streaming bodies in async client, there's no need to fallback to the blocking implementation. This should have a side-benefit of not constructing any blocking/runtime machinery while we're in an async context - this, ultimately, should prevent us from hitting the panics mentioned in #85.

I couldn't reasonably reproduce the issue from #85, so @drahnr let me know if that fixes things for you (and let's see what CI has to say first since I didn't run too much tests locally yet).