### PR TITLE
failsafe create dir

### DIFF
--- a/src/bin/cachepot-dist/build.rs
+++ b/src/bin/cachepot-dist/build.rs
@@ -186,6 +186,13 @@ impl OverlayBuilder {
                 entry.build_count += 1;
                 entry.clone()
             } else {
+                if toolchain_dir.exists() {
+                    warn!(
+                        "Toolchain directory for {} already exists, removing",
+                        tc.archive_id
+                    );
+                    fs::remove_dir_all(&toolchain_dir)?;
+                }
                 trace!("Creating toolchain directory for {}", tc.archive_id);
                 fs::create_dir(&toolchain_dir)?;
 


### PR DESCRIPTION
If a file or directory exists under the designated toolchain directory, with the identical hash, this indicates a fluke with the server (restart while the toolchain was uploaded i.e.) and hence we should gracefully remove this file if present, but not present in the toolchain cache if a client attempts to upload the toolchain.