### PR TITLE
Updates rustc -Z ls output format

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -2296,6 +2296,10 @@ impl RlibDepReader {
 // Parse output like the following:
 //
 // ```
+// Crate info:
+// name itoa-292f0c0aa4cceb9b
+// hash bad7b4d042d5e1e2 stable_crate_id StableCrateId(10504034775541642711)
+// proc_macro false
 // =External Dependencies=
 // 1 std-08a5bd1ca58a28ee
 // 2 core-ed31c38c1a60e6f9
@@ -2311,7 +2315,7 @@ impl RlibDepReader {
 // ```
 #[cfg(feature = "dist-client")]
 fn parse_rustc_z_ls(stdout: &str) -> Result<Vec<&str>> {
-    let mut lines = stdout.lines();
+    let mut lines = stdout.lines().skip(4);
     match lines.next() {
         Some("=External Dependencies=") => {}
         Some(s) => bail!("Unknown first line from rustc -Z ls: {}", s),

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -2948,7 +2948,11 @@ c:/foo/bar.rs:
     #[cfg(feature = "dist-client")]
     #[test]
     fn test_parse_rustc_z_ls() {
-        let output = "=External Dependencies=
+        let output = "Crate info:
+name itoa-292f0c0aa4cceb9b
+hash bad7b4d042d5e1e2 stable_crate_id StableCrateId(10504034775541642711)
+proc_macro false
+=External Dependencies=
 1 lucet_runtime
 2 lucet_runtime_internals-1ff6232b6940e924
 3 lucet_runtime_macros-c18e1952b835769e


### PR DESCRIPTION
After rust-lang/rust#86045 the output of `rustc -Z ls` has been changes which made `cachepot`'s dist fail with a warning:

```
[2021-11-10T13:05:46Z WARN  cachepot::compiler::rust] Failed to initialise RlibDepDecoder, distributed compiles will be inefficient: Failed to read deps from minimal rlib: Unknown first line from rustc -Z ls: Crate info:
```