### PR TITLE
ci: Use nightly-2021-11-01 for smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,11 @@ jobs:
         include:
           - target_repository: paritytech/polkadot
             # Pin a well-known nightly version to avoid upstream breakage
-            rustc: nightly-2021-10-04
+            rustc: nightly-2021-11-01
             target: wasm32-unknown-unknown
             allow_failure: true
           - target_repository: paritytech/substrate
-            rustc: nightly-2021-10-04
+            rustc: nightly-2021-11-01
             target: wasm32-unknown-unknown
             allow_failure: true
           - target_repository: serde-rs/serde


### PR DESCRIPTION
Fixes the following error:
```
error[E0658]: use of unstable library feature 'proc_macro_is_available'
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.33/src/detection.rs:28:21
   |
28 |     let available = proc_macro::is_available();
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #71436 <https://github.com/rust-lang/rust/issues/71436> for more information
   = help: add `#![feature(proc_macro_is_available)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
error: could not compile `proc-macro2` due to previous error
```