### PR TITLE
Configure CNAME when deploying gh-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,3 +47,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/book/book/html/
+        cname: cachepot.cc


### PR DESCRIPTION
Previously, it seems that we deployed our built mdbook and overwrote
everything else, including CNAME. To not manually touch CNAME everytime
we deploy the pages, let's specify CNAME ourselves in the
`actions-gh-pages` action directly.