### PR TITLE
migrate to clap 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +286,7 @@ dependencies = [
  "bytes 1.1.0",
  "cc",
  "chrono",
+ "clap",
  "counted-array",
  "crossbeam-utils",
  "daemonize",
@@ -347,7 +339,6 @@ dependencies = [
  "sha-1",
  "sha2",
  "strip-ansi-escapes",
- "structopt",
  "strum",
  "syslog",
  "tar",
@@ -418,17 +409,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -998,6 +1004,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1644,6 +1656,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2632,33 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -2675,7 +2672,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2775,12 +2772,9 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thirtyfour"
@@ -3195,12 +3189,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ walkdir = "2"
 which = { version = "4", default-features = false }
 zip = { version = "0.5", default-features = false }
 zstd = "0.6"
-structopt = "0.3.25"
+clap = { version = "3.1", features = ["derive", "env"] }
 strum = { version = "0.23.0", features = ["derive"] }
 native-tls = "0.2.8"
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -13,30 +13,38 @@
 // limitations under the License.
 
 use crate::errors::*;
+use clap::{ArgEnum, ArgGroup, StructOpt};
 use std::convert::{TryFrom, TryInto};
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
-use structopt::{
-    clap::{arg_enum, AppSettings, ArgGroup},
-    StructOpt,
-};
 use strum::{EnumVariantNames, VariantNames};
 
-arg_enum! {
-    #[derive(EnumVariantNames, StructOpt, Debug)]
-    #[allow(non_camel_case_types)]
-    pub enum StatsFormat {
-        text,
-        json
+#[derive(Copy, Clone, EnumVariantNames, ArgEnum, StructOpt, Debug)]
+#[allow(non_camel_case_types)]
+pub enum StatsFormat {
+    text,
+    json,
+}
+
+impl std::str::FromStr for StatsFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        for variant in Self::value_variants() {
+            if variant.to_possible_value().unwrap().matches(s, false) {
+                return Ok(*variant);
+            }
+        }
+        Err(format!("Invalid variant: {}", s))
     }
 }
 
 #[derive(Debug, StructOpt)]
 #[structopt(
     rename_all = "kebab-case",
-    group = ArgGroup::with_name("flags"),
-    global_settings = &[AppSettings::TrailingVarArg],
+    trailing_var_arg = true,
+    group = ArgGroup::new("flags"),
     after_help = concat!(
 "Enabled features:\n",
 "    S3:        ", cfg!(feature = "s3"), "\n",
@@ -78,20 +86,15 @@ pub struct Command2 {
     #[structopt(
         long,
         required = false,
-        use_delimiter = true,
-        value_delimiter = " ",
+        use_value_delimiter = true,
+        value_delimiter = ' ',
         value_names = &["executable", "out"],
         takes_value = true,
         number_of_values = 2,
     )]
     package_toolchain: Vec<PathBuf>,
 
-    #[structopt(
-        long,
-        hidden = true,
-        group = "flags",
-        env = "CACHEPOT_START_COORDINATOR"
-    )]
+    #[structopt(long, hide = true, group = "flags", env = "CACHEPOT_START_COORDINATOR")]
     internal_start_coordinator: Option<String>,
 
     /// set output format of statistics
@@ -193,6 +196,6 @@ pub enum Command {
 
 /// Parse the commandline into a `Command` to execute.
 pub fn parse() -> Result<Command> {
-    let a = Command2::from_args();
+    let a = Command2::parse();
     Ok(a.try_into()?)
 }


### PR DESCRIPTION
A new version of `clap` is out there, so bump and minimal migrate.