### PR TITLE
Fix aarch64-unknown-linux-musl build by puliing GCC 10 specifically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
           sudo apt-get install musl-dev:arm64 binutils-multiarch gcc-10-aarch64-linux-gnu libc6-dev-arm64-cross
           apt-get download musl-tools:arm64
           sudo dpkg-deb -x musl-tools_*_arm64.deb /
-          sed 2iREALGCC=aarch64-linux-gnu-gcc /usr/bin/musl-gcc | sudo tee /usr/bin/aarch64-linux-musl-gcc > /dev/null
+          sed 2iREALGCC=aarch64-linux-gnu-gcc-10 /usr/bin/musl-gcc | sudo tee /usr/bin/aarch64-linux-musl-gcc > /dev/null
           sudo chmod +x /usr/bin/aarch64-linux-musl-gcc
         if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
           echo deb [arch=arm64] http://azure.ports.ubuntu.com/ubuntu-ports/ $(lsb_release -c -s) main restricted universe multiverse | sudo tee /etc/apt/sources.list.d/99ports.list > /dev/null
           sudo dpkg --add-architecture arm64
           sudo apt-get update --fix-missing || true
-          sudo apt-get install musl-dev:arm64 binutils-multiarch gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+          sudo apt-get install musl-dev:arm64 binutils-multiarch gcc-10-aarch64-linux-gnu libc6-dev-arm64-cross
           apt-get download musl-tools:arm64
           sudo dpkg-deb -x musl-tools_*_arm64.deb /
           sed 2iREALGCC=aarch64-linux-gnu-gcc /usr/bin/musl-gcc | sudo tee /usr/bin/aarch64-linux-musl-gcc > /dev/null

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -647,7 +647,7 @@ impl RustupProxy {
         // `rustc +stable` returns retcode 1 (!=0) if it is installed via i.e. rpm packages
 
         // verify rustc is proxy
-        let mut child = creator.new_command_sync(compiler_executable.to_owned());
+        let mut child = creator.new_command_sync(compiler_executable);
         child.env_clear().envs(ref_env(env)).args(&["+stable"]);
         let state = run_input_output(child, None).await.map(move |output| {
             if output.status.success() {
@@ -710,7 +710,7 @@ impl RustupProxy {
             Ok(ProxyPath::None) => Ok(Ok(None)),
             Ok(ProxyPath::Candidate(proxy_executable)) => {
                 // verify the candidate is a rustup
-                let mut child = creator.new_command_sync(proxy_executable.to_owned());
+                let mut child = creator.new_command_sync(proxy_executable);
                 child.env_clear().envs(ref_env(env)).args(&["--version"]);
                 let rustup_candidate_check = run_input_output(child, None).await?;
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -708,7 +708,7 @@ impl RustupProxy {
                 "Failed to discover a rustup executable, but rustc behaves like a proxy"
             ))),
             Ok(ProxyPath::None) => Ok(Ok(None)),
-            Ok(ProxyPath::Candidate(proxy_executable)) => {
+            Ok(ProxyPath::Candidate(ref proxy_executable)) => {
                 // verify the candidate is a rustup
                 let mut child = creator.new_command_sync(proxy_executable);
                 child.env_clear().envs(ref_env(env)).args(&["--version"]);
@@ -718,7 +718,7 @@ impl RustupProxy {
                     .map_err(|_e| anyhow!("Response of `rustup --version` is not valid UTF-8"))?;
                 Ok(if stdout.trim().starts_with("rustup ") {
                     trace!("PROXY rustup --version produced: {}", &stdout);
-                    Self::new(&proxy_executable).map(Some)
+                    Self::new(proxy_executable).map(Some)
                 } else {
                     Err(anyhow!("Unexpected output or `rustup --version`"))
                 })


### PR DESCRIPTION
Previously, there would occur a mismatch on the GCC 9 version,
preventing us from installing it properly. Instead of that, try just
pulling GCC 10 rather than both 9 and 10.